### PR TITLE
Practice branch with no max quantity

### DIFF
--- a/app/models/discount.rb
+++ b/app/models/discount.rb
@@ -2,7 +2,6 @@ class Discount < ApplicationRecord
   validates_presence_of :name,
                         :description,
                         :min_quantity,
-                        :max_quantity,
                         :percent
 
   belongs_to :merchant

--- a/app/views/merchant/discounts/_form.html.erb
+++ b/app/views/merchant/discounts/_form.html.erb
@@ -8,9 +8,6 @@
   <%= label_tag :min_quantity %>
   <%= text_field_tag :min_quantity, @discount ? @discount.min_quantity : "" %>
 
-  <%= label_tag :max_quantity %>
-  <%= text_field_tag :max_quantity, @discount ? @discount.max_quantity : "" %>
-
   <%= label_tag :percent %>
   <%= text_field_tag :percent, @discount ? @discount.percent : "" %>
 

--- a/app/views/merchant/discounts/edit.html.erb
+++ b/app/views/merchant/discounts/edit.html.erb
@@ -8,9 +8,6 @@
   <%= label_tag :min_quantity %>
   <%= text_field_tag :min_quantity, @discount.min_quantity %>
 
-  <%= label_tag :max_quantity %>
-  <%= text_field_tag :max_quantity, @discount.max_quantity %>
-
   <%= label_tag :percent %>
   <%= text_field_tag :percent, @discount.percent %>
 

--- a/app/views/merchant/discounts/new.html.erb
+++ b/app/views/merchant/discounts/new.html.erb
@@ -8,9 +8,6 @@
   <%= label_tag :min_quantity %>
   <%= text_field_tag :min_quantity %>
 
-  <%= label_tag :max_quantity %>
-  <%= text_field_tag :max_quantity %>
-
   <%= label_tag :percent %>
   <%= text_field_tag :percent %>
 

--- a/app/views/merchant/discounts/show.html.erb
+++ b/app/views/merchant/discounts/show.html.erb
@@ -5,5 +5,4 @@
 
 <h3>Description: <%= @discount.description %></h3>
 <h3>Minimum Item Quantity: <%= @discount.min_quantity %></h3>
-<h3>Maximum Item Quantity: <%= @discount.max_quantity %></h3>
 <h3>Discount Percentage: <%= @discount.percent %></h3>

--- a/db/migrate/20200229212938_create_discounts.rb
+++ b/db/migrate/20200229212938_create_discounts.rb
@@ -5,7 +5,6 @@ class CreateDiscounts < ActiveRecord::Migration[5.1]
       t.string :description
       t.references :merchant, foreign_key: true
       t.integer :min_quantity
-      t.integer :max_quantity
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20200229223207) do
     t.string "description"
     t.bigint "merchant_id"
     t.integer "min_quantity"
-    t.integer "max_quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "percent"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,8 +27,8 @@ jeff = car_shop.users.create!(name: "Jeff Gordon", address: "571 Nascar St",
 
 bike_shop = Merchant.create!(name: 'Flat Tire', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
 
-discount_1 = bike_shop.discounts.create!(name: "Test_1 Discount", description: "Great bulk discount", min_quantity: 5, max_quantity: 9, percent: 10)
-discount_2 = bike_shop.discounts.create!(name: "Test_2 Discount", description: "Greater bulk discount", min_quantity: 10, max_quantity: 100, percent: 20)
+discount_1 = bike_shop.discounts.create!(name: "Test_1 Discount", description: "Great bulk discount", min_quantity: 5, percent: 10)
+discount_2 = bike_shop.discounts.create!(name: "Test_2 Discount", description: "Greater bulk discount", min_quantity: 10, percent: 20)
 #bike_shop employee
 lance = bike_shop.users.create!(name: "Lance Armstrong", address: "571 Cheater St",
   city: "Colorado Springs", state: "CO", zip: "80206", email: "lance@gmail.com", password: "lance", role: 2)
@@ -46,8 +46,8 @@ cranks = bike_shop.items.create(name: "carbon cranks ", description: "LIGHT", pr
 
 dog_shop = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
 
-discount_3 = dog_shop.discounts.create!(name: "Test_3 Discount", description: "Dog Shop bulk discount", min_quantity: 5, max_quantity: 9, percent: 10)
-discount_4 = dog_shop.discounts.create!(name: "Test_4 Discount", description: "Bigger Dog Shop bulk discount", min_quantity: 10, max_quantity: 100, percent: 20)
+discount_3 = dog_shop.discounts.create!(name: "Test_3 Discount", description: "Dog Shop bulk discount", min_quantity: 5, percent: 10)
+discount_4 = dog_shop.discounts.create!(name: "Test_4 Discount", description: "Bigger Dog Shop bulk discount", min_quantity: 10, percent: 20)
 
 #dog_shop employee
 abby = dog_shop.users.create!(name: "Abby Gallant", address: "678 Dog Lover St",

--- a/spec/features/discounts/discount_lowers_price_for_items_spec.rb
+++ b/spec/features/discounts/discount_lowers_price_for_items_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "As a visitor" do
     @dave = @blockbuster.users.create!(name: "Dave Chappelle", address: "571 Cheater St",
       city: "Colorado Springs", state: "CO", zip: "80206", email: "dave@gmail.com", password: "dave", role: 2)
 
-    @discount_1 = @blockbuster.discounts.create!(name: "Ten Percent", description: "Great bulk discount", min_quantity: 3, max_quantity: 4, percent: 10)
-    @discount_2 = @blockbuster.discounts.create!(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 5, max_quantity: 100, percent: 20)
+    @discount_1 = @blockbuster.discounts.create!(name: "Ten Percent", description: "Great bulk discount", min_quantity: 3, percent: 10)
+    @discount_2 = @blockbuster.discounts.create!(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 5, percent: 20)
 
     @ogre = @blockbuster.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 10, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 20 )
     @giant = @blockbuster.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 20 )

--- a/spec/features/merchant/discount_edit_spec.rb
+++ b/spec/features/merchant/discount_edit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "As a visitor" do
 
     @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, percent: 10)
     @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, percent: 20)
-    @discount_ = @front_row_video.discounts.create(name: "Test Discount", description: "Competitor's Discount", min_quantity: 20, percent: 50)
+    @discount_3 = @front_row_video.discounts.create(name: "Test Discount", description: "Competitor's Discount", min_quantity: 20, percent: 50)
 
     visit '/login'
     expect(current_path).to eq('/login')

--- a/spec/features/merchant/discount_edit_spec.rb
+++ b/spec/features/merchant/discount_edit_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe "As a visitor" do
   before :each do
     Merchant.destroy_all
     Discount.destroy_all
-    
+
+    @front_row_video = Merchant.create!(name: 'Front Row Video', address: '874 New Hampshire Blvd', city: 'Bangor', state: 'PA', zip: 80218, enabled: true)
     @blockbuster = Merchant.create!(name: 'Blockbuster', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, enabled: true)
     @dave = @blockbuster.users.create!(name: "Dave Chappelle", address: "571 Cheater St",
       city: "Colorado Springs", state: "CO", zip: "80206", email: "dave@gmail.com", password: "dave", role: 2)
 
-    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, max_quantity: 19, percent: 10)
-    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, max_quantity: 100, percent: 20)
+    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, percent: 10)
+    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, percent: 20)
+    @discount_ = @front_row_video.discounts.create(name: "Test Discount", description: "Competitor's Discount", min_quantity: 20, percent: 50)
 
     visit '/login'
     expect(current_path).to eq('/login')
@@ -25,6 +27,8 @@ RSpec.describe "As a visitor" do
   end
 
   it "has a link to edit the discount on the discount's show page" do
+    expect(page).to_not have_content("Test Discount")
+
     click_link "#{@discount_1.name}"
     click_link "Edit"
     expect(current_path).to eq("/merchant/discounts/#{@discount_1.id}/edit")

--- a/spec/features/merchant/discount_edit_spec.rb
+++ b/spec/features/merchant/discount_edit_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "As a visitor" do
   end
 
   it "has a link to edit the discount on the discount's show page" do
-    expect(page).to_not have_content("Test Discount")
 
     click_link "#{@discount_1.name}"
     click_link "Edit"
@@ -51,5 +50,11 @@ RSpec.describe "As a visitor" do
     click_on "Update"
     expect(current_path).to eq("/merchant/discounts/#{@discount_1.id}/edit")
     expect(page).to have_content("Your discount changes have not been saved.")
+  end
+
+  it "only shows discounts associated with logged in merchant" do
+    expect(page).to have_content("Fifteen Percent")
+    expect(page).to have_content("Ten Percent")
+    expect(page).to_not have_content("Test Discount")
   end
 end

--- a/spec/features/merchant/discounts_index_spec.rb
+++ b/spec/features/merchant/discounts_index_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe "As a visitor" do
     fill_in :name, with: "New Discount"
     fill_in :description, with: "Newest discount available"
     fill_in :min_quantity, with: 5
-    # fill_in :max_quantity, with: 9
     fill_in :percent, with: 50
     click_button "Submit"
 

--- a/spec/features/merchant/discounts_index_spec.rb
+++ b/spec/features/merchant/discounts_index_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "As a visitor" do
     @dave = @blockbuster.users.create!(name: "Dave Chappelle", address: "571 Cheater St",
       city: "Colorado Springs", state: "CO", zip: "80206", email: "dave@gmail.com", password: "dave", role: 2)
 
-    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, max_quantity: 19, percent: 10)
-    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, max_quantity: 100, percent: 20)
+    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, percent: 10)
+    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, percent: 20)
 
     visit '/login'
     expect(current_path).to eq('/login')
@@ -44,7 +44,7 @@ RSpec.describe "As a visitor" do
     fill_in :name, with: "New Discount"
     fill_in :description, with: "Newest discount available"
     fill_in :min_quantity, with: 5
-    fill_in :max_quantity, with: 9
+    # fill_in :max_quantity, with: 9
     fill_in :percent, with: 50
     click_button "Submit"
 
@@ -62,13 +62,12 @@ RSpec.describe "As a visitor" do
 
     fill_in :name, with: "New Discount"
     fill_in :description, with: "Newest discount available"
-    fill_in :min_quantity, with: 5
-    fill_in :max_quantity, with: ""
+    fill_in :min_quantity, with: ""
     fill_in :percent, with: 50
     click_button "Submit"
 
     expect(current_path).to eq("/merchant/discounts/new")
-    expect(page).to have_content("Max quantity can't be blank")
+    expect(page).to have_content("Min quantity can't be blank")
   end
 
   it "has a link to delete a discount next to each discount on the index page" do

--- a/spec/features/merchant/discounts_show_spec.rb
+++ b/spec/features/merchant/discounts_show_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "As a visitor" do
     @dave = @blockbuster.users.create!(name: "Dave Chappelle", address: "571 Cheater St",
       city: "Colorado Springs", state: "CO", zip: "80206", email: "dave@gmail.com", password: "dave", role: 2)
 
-    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, max_quantity: 19, percent: 10)
-    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, max_quantity: 100, percent: 20)
+    @discount_1 = @blockbuster.discounts.create(name: "Ten Percent", description: "Great bulk discount", min_quantity: 10, percent: 10)
+    @discount_2 = @blockbuster.discounts.create(name: "Fifteen Percent", description: "Best discount offered", min_quantity: 20, percent: 20)
 
     visit '/login'
     expect(current_path).to eq('/login')
@@ -27,10 +27,9 @@ RSpec.describe "As a visitor" do
     expect(page).to have_content("Discount for: #{@blockbuster.name}")
     expect(current_path).to eq("/merchant/discounts/#{@discount_1.id}")
     expect(page).to have_content(@discount_1.name)
-    
+
     expect(page).to have_content("Description: #{@discount_1.description}")
     expect(page).to have_content("Minimum Item Quantity: #{@discount_1.min_quantity}")
-    expect(page).to have_content("Maximum Item Quantity: #{@discount_1.max_quantity}")
     expect(page).to have_content("Discount Percentage: #{@discount_1.percent}")
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Cart do
                                     active: true,
                                     inventory: 10 )
 
-      @discount_1 = @megan.discounts.create!(name: "Test_1 Discount", description: "Great bulk discount", min_quantity: 3, max_quantity: 4, percent: 10)
-      @discount_2 = @megan.discounts.create!(name: "Test_2 Discount", description: "Greater bulk discount", min_quantity: 5, max_quantity: 100, percent: 20)
+      @discount_1 = @megan.discounts.create!(name: "Test_1 Discount", description: "Great bulk discount", min_quantity: 3, percent: 10)
+      @discount_2 = @megan.discounts.create!(name: "Test_2 Discount", description: "Greater bulk discount", min_quantity: 5, percent: 20)
 
       @cart = Cart.new({
         @ogre.id.to_s => 1,

--- a/spec/models/discount_spec.rb
+++ b/spec/models/discount_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Discount do
     it {should validate_presence_of :name}
     it {should validate_presence_of :description}
     it {should validate_presence_of :min_quantity}
-    it {should validate_presence_of :max_quantity}
     it {should validate_presence_of :percent}
   end
 


### PR DESCRIPTION
Remove the attribute 'max_quantity' from everything associated with discounts. The way I wrote the functionality makes it unnecessary. All tests, 258 at this point, are still passing.